### PR TITLE
New factory functions

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,0 +1,27 @@
+package substate
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+)
+
+// NewDb creates a new instance of DB from given path.
+func NewDb(path string, readOnly bool) (*DB, error) {
+	backend, err := rawdb.NewLevelDBDatabase(path, 1024, 100, substateNamespace, readOnly)
+	if err != nil {
+		return nil, fmt.Errorf("error opening leveldb %s; %v", substateDir, err)
+	}
+	return newSubstateDB(backend), nil
+}
+
+// MakeDb creates a new instance of DB from given backend.
+func MakeDb(backend BackendDatabase) *DB {
+	// todo Rename to OpenSubstateDb after deprecated functions are removed
+	return newSubstateDB(backend)
+}
+
+// NewInMemoryDb creates new instance of in-memory DB
+func NewInMemoryDb() *DB {
+	return newSubstateDB(rawdb.NewMemoryDatabase())
+}

--- a/static_substate_db.go
+++ b/static_substate_db.go
@@ -9,40 +9,50 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const substateNamespace = "substatedir"
+
 var (
 	SubstateDbFlag = cli.StringFlag{
 		Name:  "substate-db",
 		Usage: "Data directory for substate recorder/replayer",
 	}
 	substateDir      = SubstateDbFlag.Value
-	staticSubstateDB *SubstateDB
+	staticSubstateDB *DB
 	RecordReplay     bool = false
 )
 
+// Deprecated: Please use NewDb instead. This function
+// relies on a global variable which will be removed in the future.
 func OpenSubstateDB() {
 	fmt.Println("record-replay: OpenSubstateDB")
-	backend, err := rawdb.NewLevelDBDatabase(substateDir, 1024, 100, "substatedir", false)
+	backend, err := rawdb.NewLevelDBDatabase(substateDir, 1024, 100, substateNamespace, false)
 	if err != nil {
 		panic(fmt.Errorf("error opening substate leveldb %s: %v", substateDir, err))
 	}
 	fmt.Println("record-replay: opened successfully")
-	staticSubstateDB = NewSubstateDB(backend)
+	staticSubstateDB = newSubstateDB(backend)
 }
 
+// Deprecated: Please use NewDb instead. This function
+// relies on a global variable which will be removed in the future.
 func OpenSubstateDBReadOnly() {
 	fmt.Println("record-replay: OpenSubstateDB")
-	backend, err := rawdb.NewLevelDBDatabase(substateDir, 1024, 100, "substatedir", true)
+	backend, err := rawdb.NewLevelDBDatabase(substateDir, 1024, 100, substateNamespace, true)
 	if err != nil {
 		panic(fmt.Errorf("error opening substate leveldb %s: %v", substateDir, err))
 	}
-	staticSubstateDB = NewSubstateDB(backend)
+	staticSubstateDB = newSubstateDB(backend)
 }
 
+// Deprecated: Please use MakeDb instead. This function
+// relies on a global variable which will be removed in the future.
 func SetSubstateDbBackend(backend ethdb.Database) {
 	fmt.Println("record-replay: SetSubstateDB")
-	staticSubstateDB = NewSubstateDB(backend)
+	staticSubstateDB = newSubstateDB(backend)
 }
 
+// Deprecated: Please use NewDb or MakeDb to create new DB and call the method Close() from
+// returned object. This function relies on a global variable which will be removed in the future.
 func CloseSubstateDB() {
 	defer fmt.Println("record-replay: CloseSubstateDB")
 
@@ -52,6 +62,8 @@ func CloseSubstateDB() {
 	}
 }
 
+// Deprecated: Please use NewDb or MakeDb to create new DB and call the method Compact() from
+// returned object. This function relies on a global variable which will be removed in the future.
 func CompactSubstateDB() {
 	fmt.Println("record-replay: CompactSubstateDB")
 
@@ -62,20 +74,26 @@ func CompactSubstateDB() {
 	}
 }
 
+// Deprecated: Please use NewInMemoryDb instead. This function
+// relies on a global variable which will be removed in the future.
 func OpenFakeSubstateDB() {
 	backend := rawdb.NewMemoryDatabase()
-	staticSubstateDB = NewSubstateDB(backend)
+	staticSubstateDB = newSubstateDB(backend)
 }
 
+// Deprecated: Please use NewInMemoryDb to create new in-memory DB and call the method Close() from
+// returned object. This function relies on a global variable which will be removed in the future.
 func CloseFakeSubstateDB() {
 	staticSubstateDB.Close()
 }
 
+// Deprecated: This function relies on a global variable which will be removed in the future.
 func SetSubstateDbFlags(ctx *cli.Context) {
 	substateDir = ctx.String(SubstateDbFlag.Name)
 	fmt.Printf("record-replay: --substatedir=%s\n", substateDir)
 }
 
+// Deprecated: This function relies on a global variable which will be removed in the future.
 func SetSubstateDb(dir string) {
 	substateDir = dir
 }

--- a/substate_rlp.go
+++ b/substate_rlp.go
@@ -36,7 +36,7 @@ func NewSubstateAccountRLP(sa *SubstateAccount) *SubstateAccountRLP {
 	return &saRLP
 }
 
-func (sa *SubstateAccount) SetRLP(saRLP *SubstateAccountRLP, db *SubstateDB) {
+func (sa *SubstateAccount) SetRLP(saRLP *SubstateAccountRLP, db *DB) {
 	sa.Balance = saRLP.Balance
 	sa.Nonce = saRLP.Nonce
 	sa.Code = db.GetCode(saRLP.CodeHash)
@@ -71,7 +71,7 @@ func NewSubstateAllocRLP(alloc SubstateAlloc) SubstateAllocRLP {
 	return allocRLP
 }
 
-func (alloc *SubstateAlloc) SetRLP(allocRLP SubstateAllocRLP, db *SubstateDB) {
+func (alloc *SubstateAlloc) SetRLP(allocRLP SubstateAllocRLP, db *DB) {
 	*alloc = make(SubstateAlloc)
 	for i, addr := range allocRLP.Addresses {
 		var sa SubstateAccount
@@ -147,7 +147,7 @@ func NewSubstateEnvRLP(env *SubstateEnv) *SubstateEnvRLP {
 	return &envRLP
 }
 
-func (env *SubstateEnv) SetRLP(envRLP *SubstateEnvRLP, db *SubstateDB) {
+func (env *SubstateEnv) SetRLP(envRLP *SubstateEnvRLP, db *DB) {
 	env.Coinbase = envRLP.Coinbase
 	env.Difficulty = envRLP.Difficulty
 	env.GasLimit = envRLP.GasLimit
@@ -286,7 +286,7 @@ func NewSubstateMessageRLP(msg *SubstateMessage) *SubstateMessageRLP {
 	return &msgRLP
 }
 
-func (msg *SubstateMessage) SetRLP(msgRLP *SubstateMessageRLP, db *SubstateDB) {
+func (msg *SubstateMessage) SetRLP(msgRLP *SubstateMessageRLP, db *DB) {
 	msg.Nonce = msgRLP.Nonce
 	msg.CheckNonce = msgRLP.CheckNonce
 	msg.GasPrice = msgRLP.GasPrice
@@ -329,7 +329,7 @@ func NewSubstateResultRLP(result *SubstateResult) *SubstateResultRLP {
 	return &resultRLP
 }
 
-func (result *SubstateResult) SetRLP(resultRLP *SubstateResultRLP, db *SubstateDB) {
+func (result *SubstateResult) SetRLP(resultRLP *SubstateResultRLP, db *DB) {
 	result.Status = resultRLP.Status
 	result.Bloom = resultRLP.Bloom
 	result.Logs = resultRLP.Logs
@@ -394,7 +394,7 @@ func NewSubstateRLP(substate *Substate) *SubstateRLP {
 	return &substateRLP
 }
 
-func (substate *Substate) SetRLP(substateRLP *SubstateRLP, db *SubstateDB) {
+func (substate *Substate) SetRLP(substateRLP *SubstateRLP, db *DB) {
 	substate.InputAlloc = make(SubstateAlloc)
 	substate.OutputAlloc = make(SubstateAlloc)
 	substate.Env = &SubstateEnv{}

--- a/substate_task.go
+++ b/substate_task.go
@@ -49,7 +49,7 @@ type SubstateTaskPool struct {
 
 	Ctx *cli.Context // CLI context required to read additional flags
 
-	DB *SubstateDB
+	DB *DB
 }
 
 func NewSubstateTaskPool(name string, taskFunc SubstateTaskFunc, first, last uint64, ctx *cli.Context) *SubstateTaskPool {


### PR DESCRIPTION
This PR starts the refactoring of this repository.
It:

1. Creates new factory functions, that return the `SubstateDb` object.
2. Marks old factory functions as deprecated due to using global variables, which will be removed in the future.
3. Renames `SubstateDb` -> `DB` because `substate` is the name of the package.