### PR TITLE
Fix base fee nilptr

### DIFF
--- a/rlp/rlp_env.go
+++ b/rlp/rlp_env.go
@@ -51,6 +51,11 @@ type Env struct {
 
 // ToSubstate transforms e from Env to substate.Env.
 func (e Env) ToSubstate() *substate.Env {
+	var baseFee *big.Int
+	if e.BaseFee != nil {
+		baseFee = e.BaseFee.Big()
+	}
+
 	se := &substate.Env{
 		Coinbase:    e.Coinbase,
 		Difficulty:  e.Difficulty,
@@ -58,7 +63,7 @@ func (e Env) ToSubstate() *substate.Env {
 		Number:      e.Number,
 		Timestamp:   e.Timestamp,
 		BlockHashes: make(map[uint64]types.Hash),
-		BaseFee:     new(big.Int).SetBytes(e.BaseFee[:]),
+		BaseFee:     baseFee,
 	}
 
 	// iterate through BlockHashes

--- a/types/hash.go
+++ b/types/hash.go
@@ -35,6 +35,9 @@ func (h Hash) IsEmpty() bool {
 // Uint64 converts a hash to a uint64.
 func (h Hash) Uint64() uint64 { return new(big.Int).SetBytes(h[:]).Uint64() }
 
+// Big converts a hash to a big integer.
+func (h Hash) Big() *big.Int { return new(big.Int).SetBytes(h[:]) }
+
 // Compare two big int representations of h and h2.
 func (h Hash) Compare(h2 Hash) int {
 	b1 := new(big.Int).SetBytes(h[:])


### PR DESCRIPTION
This PR fixes a `nilptr` dereference when `BaseFee` is nil. 
It also adds `Big()` func to `types.Hash` which converts given hash to `*big.Int`