### PR TITLE
Create bloom type

### DIFF
--- a/db/substate_db_test.go
+++ b/db/substate_db_test.go
@@ -24,7 +24,7 @@ var testSubstate = &substate.Substate{
 		BaseFee:     new(big.Int).SetUint64(1),
 	},
 	Message:     substate.NewMessage(1, true, new(big.Int).SetUint64(1), 1, types.Address{1}, new(types.Address), new(big.Int).SetUint64(1), []byte{1}, nil, types.AccessList{}, new(big.Int).SetUint64(1), new(big.Int).SetUint64(1)),
-	Result:      substate.NewResult(1, []byte{}, []*types.Log{}, types.Address{1}, 1),
+	Result:      substate.NewResult(1, types.Bloom{}, []*types.Log{}, types.Address{1}, 1),
 	Block:       37_534_834,
 	Transaction: 1,
 }

--- a/rlp/rlp_result.go
+++ b/rlp/rlp_result.go
@@ -17,7 +17,7 @@ func NewResult(result *substate.Result) *Result {
 
 type Result struct {
 	Status uint64
-	Bloom  []byte
+	Bloom  types.Bloom
 	Logs   []*types.Log
 
 	ContractAddress types.Address

--- a/substate/result.go
+++ b/substate/result.go
@@ -11,13 +11,13 @@ import (
 // Result is the transaction result - hence receipt
 type Result struct {
 	Status          uint64
-	Bloom           []byte
+	Bloom           types.Bloom
 	Logs            []*types.Log
 	ContractAddress types.Address
 	GasUsed         uint64
 }
 
-func NewResult(status uint64, bloom []byte, logs []*types.Log, contractAddress types.Address, gasUsed uint64) *Result {
+func NewResult(status uint64, bloom types.Bloom, logs []*types.Log, contractAddress types.Address, gasUsed uint64) *Result {
 	return &Result{
 		Status:          status,
 		Bloom:           bloom,

--- a/substate/result_test.go
+++ b/substate/result_test.go
@@ -21,8 +21,8 @@ func TestAccount_EqualStatus(t *testing.T) {
 }
 
 func TestAccount_EqualBloom(t *testing.T) {
-	res := &Result{Bloom: []byte{0}}
-	comparedRes := &Result{Bloom: []byte{1}}
+	res := &Result{Bloom: types.Bloom{0}}
+	comparedRes := &Result{Bloom: types.Bloom{1}}
 
 	if res.Equal(comparedRes) {
 		t.Fatal("results Bloom are different but equal returned true")

--- a/types/bloom.go
+++ b/types/bloom.go
@@ -1,0 +1,35 @@
+package types
+
+import "fmt"
+
+const (
+	// BloomByteLength represents the number of bytes used in a header log bloom.
+	BloomByteLength = 256
+
+	// BloomBitLength represents the number of bits used in a header log bloom.
+	BloomBitLength = 8 * BloomByteLength
+)
+
+// Bloom represents a 2048 bit bloom filter.
+type Bloom [BloomByteLength]byte
+
+// BytesToBloom converts a byte slice to a bloom filter.
+// It panics if b is not of suitable size.
+func BytesToBloom(b []byte) Bloom {
+	var bloom Bloom
+	bloom.SetBytes(b)
+	return bloom
+}
+
+// SetBytes sets the content of b to the given bytes.
+// It panics if d is not of suitable size.
+func (b *Bloom) SetBytes(d []byte) {
+	if len(b) < len(d) {
+		panic(fmt.Sprintf("bloom bytes too big %d %d", len(b), len(d)))
+	}
+	copy(b[BloomByteLength-len(d):], d)
+}
+
+func (b Bloom) Bytes() []byte {
+	return b[:]
+}


### PR DESCRIPTION
This PR creates `types.Bloom`. Aida counts on this type with its struct functions.