### PR TITLE
Sort errs

### DIFF
--- a/db/base_db.go
+++ b/db/base_db.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -87,7 +86,7 @@ func MakeDefaultBaseDBFromBaseDB(db BaseDB) BaseDB {
 func newBaseDB(path string, o *opt.Options, wo *opt.WriteOptions, ro *opt.ReadOptions) (*baseDB, error) {
 	b, err := leveldb.OpenFile(path, o)
 	if err != nil {
-		return nil, fmt.Errorf("cannot open leveldb; %v", err)
+		return nil, fmt.Errorf("cannot open leveldb; %w", err)
 	}
 	return &baseDB{
 		backend: b,
@@ -124,13 +123,7 @@ func (db *baseDB) Has(key []byte) (bool, error) {
 }
 
 func (db *baseDB) Get(key []byte) ([]byte, error) {
-	b, err := db.backend.Get(key, db.ro)
-	if err != nil {
-		if errors.Is(err, leveldb.ErrNotFound) {
-			return nil, nil
-		}
-	}
-	return b, nil
+	return db.backend.Get(key, db.ro)
 }
 
 func (db *baseDB) NewBatch() Batch {

--- a/db/code_db.go
+++ b/db/code_db.go
@@ -81,7 +81,7 @@ func (db *codeDB) GetCode(codeHash types.Hash) ([]byte, error) {
 	key := CodeDBKey(codeHash)
 	code, err := db.Get(key)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get code %s: %v", codeHash, err)
+		return nil, fmt.Errorf("cannot get code %s: %w", codeHash, err)
 	}
 	return code, nil
 }
@@ -92,7 +92,7 @@ func (db *codeDB) PutCode(code []byte) error {
 	key := CodeDBKey(codeHash)
 	err := db.Put(key, code)
 	if err != nil {
-		return fmt.Errorf("cannot put code %s: %v", codeHash, err)
+		return fmt.Errorf("cannot put code %s: %w", codeHash, err)
 	}
 
 	return nil
@@ -107,7 +107,7 @@ func (db *codeDB) DeleteCode(codeHash types.Hash) error {
 	key := CodeDBKey(codeHash)
 	err := db.Delete(key)
 	if err != nil {
-		return fmt.Errorf("cannot get code %s: %v", codeHash, err)
+		return fmt.Errorf("cannot delete code %s: %w", codeHash, err)
 	}
 	return nil
 }

--- a/db/substate_db.go
+++ b/db/substate_db.go
@@ -100,17 +100,12 @@ func (db *substateDB) HasSubstate(block uint64, tx int) (bool, error) {
 func (db *substateDB) GetSubstate(block uint64, tx int) (*substate.Substate, error) {
 	val, err := db.Get(SubstateDBKey(block, tx))
 	if err != nil {
-		return nil, fmt.Errorf("cannot get substate block: %v, tx: %v from db; %v", block, tx, err)
-	}
-
-	// not in db
-	if val == nil {
-		return nil, nil
+		return nil, fmt.Errorf("cannot get substate block: %v, tx: %v from db; %w", block, tx, err)
 	}
 
 	rlpSubstate, err := rlp.Decode(val)
 	if err != nil {
-		return nil, fmt.Errorf("cannot decode data into rlp block: %v, tx %v; %v", block, tx, err)
+		return nil, fmt.Errorf("cannot decode data into rlp block: %v, tx %v; %w", block, tx, err)
 	}
 
 	return rlpSubstate.ToSubstate(db.GetCode, block, tx)
@@ -131,7 +126,7 @@ func (db *substateDB) GetBlockSubstates(block uint64) (map[int]*substate.Substat
 
 		b, tx, err := DecodeSubstateDBKey(key)
 		if err != nil {
-			return nil, fmt.Errorf("record-replay: invalid substate key found for block %v: %v", block, err)
+			return nil, fmt.Errorf("record-replay: invalid substate key found for block %v: %w", block, err)
 		}
 
 		if block != b {
@@ -140,12 +135,12 @@ func (db *substateDB) GetBlockSubstates(block uint64) (map[int]*substate.Substat
 
 		rlpSubstate, err := rlp.Decode(value)
 		if err != nil {
-			return nil, fmt.Errorf("cannot decode data into rlp block: %v, tx %v; %v", block, tx, err)
+			return nil, fmt.Errorf("cannot decode data into rlp block: %v, tx %v; %w", block, tx, err)
 		}
 
 		sbstt, err := rlpSubstate.ToSubstate(db.GetCode, block, tx)
 		if err != nil {
-			return nil, fmt.Errorf("cannot decode data into substate: %v", err)
+			return nil, fmt.Errorf("cannot decode data into substate: %w", err)
 		}
 
 		txSubstate[tx] = sbstt
@@ -163,14 +158,14 @@ func (db *substateDB) PutSubstate(ss *substate.Substate) error {
 	for i, account := range ss.InputSubstate {
 		err := db.PutCode(account.Code)
 		if err != nil {
-			return fmt.Errorf("cannot put preState code from substate-account %v block %v, %v tx into db; %v", i, ss.Block, ss.Transaction, err)
+			return fmt.Errorf("cannot put preState code from substate-account %v block %v, %v tx into db; %w", i, ss.Block, ss.Transaction, err)
 		}
 	}
 
 	for i, account := range ss.OutputSubstate {
 		err := db.PutCode(account.Code)
 		if err != nil {
-			return fmt.Errorf("cannot put postState code from substate-account %v block %v, %v tx into db; %v", i, ss.Block, ss.Transaction, err)
+			return fmt.Errorf("cannot put postState code from substate-account %v block %v, %v tx into db; %w", i, ss.Block, ss.Transaction, err)
 		}
 	}
 

--- a/db/substate_iterator.go
+++ b/db/substate_iterator.go
@@ -30,7 +30,7 @@ func (i *substateIterator) decode(data rawEntry) (*substate.Substate, error) {
 
 	block, tx, err := DecodeSubstateDBKey(data.key)
 	if err != nil {
-		return nil, fmt.Errorf("invalid substate key: %v; %v", key, err)
+		return nil, fmt.Errorf("invalid substate key: %v; %w", key, err)
 	}
 
 	rlpSubstate, err := rlp.Decode(value)

--- a/db/substate_task.go
+++ b/db/substate_task.go
@@ -63,7 +63,7 @@ func (pool *SubstateTaskPool) ExecuteBlock(block uint64) (numTx int64, gas int64
 	if pool.BlockFunc != nil {
 		err := pool.BlockFunc(block, transactions, pool)
 		if err != nil {
-			return 0, 0, fmt.Errorf("%s: block %v: %v", pool.Name, block, err)
+			return 0, 0, fmt.Errorf("%s: block %v: %w", pool.Name, block, err)
 		}
 	}
 	if pool.TaskFunc == nil {
@@ -103,7 +103,7 @@ func (pool *SubstateTaskPool) ExecuteBlock(block uint64) (numTx int64, gas int64
 		}
 		err = pool.TaskFunc(block, tx, substate, pool)
 		if err != nil {
-			return 0, 0, fmt.Errorf("%s: %v_%v: %v", pool.Name, block, tx, err)
+			return 0, 0, fmt.Errorf("%s: %v_%v: %w", pool.Name, block, tx, err)
 		}
 
 		numTx++

--- a/db/update_db.go
+++ b/db/update_db.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/syndtr/goleveldb/leveldb/util"
 
@@ -84,7 +85,7 @@ func (db *updateDB) GetFirstKey() (uint64, error) {
 		}
 		return firstBlock, nil
 	}
-	return 0, errors.New("no updateset found")
+	return 0, leveldb.ErrNotFound
 }
 
 func (db *updateDB) GetLastKey() (uint64, error) {

--- a/db/update_set_iterator.go
+++ b/db/update_set_iterator.go
@@ -36,7 +36,7 @@ func (i *updateSetIterator) decode(data rawEntry) (*updateset.UpdateSet, error) 
 
 	block, err := DecodeUpdateSetKey(data.key)
 	if err != nil {
-		return nil, fmt.Errorf("substate: invalid update-set key found: %v - issue: %v", key, err)
+		return nil, fmt.Errorf("substate: invalid update-set key found: %v - issue: %w", key, err)
 	}
 
 	var updateSetRLP updateset.UpdateSetRLP

--- a/rlp/rlp_message.go
+++ b/rlp/rlp_message.go
@@ -1,10 +1,12 @@
 package rlp
 
 import (
+	"errors"
 	"math/big"
 
 	"github.com/Fantom-foundation/Substate/substate"
 	"github.com/Fantom-foundation/Substate/types"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func NewMessage(message *substate.Message) *Message {
@@ -72,7 +74,7 @@ func (m Message) ToSubstate(getHashFunc func(codeHash types.Hash) ([]byte, error
 	if sm.To == nil {
 		var err error
 		sm.Data, err = getHashFunc(*m.InitCodeHash)
-		if err != nil {
+		if err != nil && !errors.Is(err, leveldb.ErrNotFound) {
 			return nil, err
 		}
 	}

--- a/rlp/rlp_world_state.go
+++ b/rlp/rlp_world_state.go
@@ -1,8 +1,11 @@
 package rlp
 
 import (
+	"errors"
+
 	"github.com/Fantom-foundation/Substate/substate"
 	"github.com/Fantom-foundation/Substate/types"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func NewWorldState(worldState substate.WorldState) WorldState {
@@ -35,7 +38,7 @@ func (ws WorldState) ToSubstate(getHashFunc func(codeHash types.Hash) ([]byte, e
 	for i, addr := range ws.Addresses {
 		acc := ws.Accounts[i]
 		code, err := getHashFunc(acc.CodeHash)
-		if err != nil {
+		if err != nil && !errors.Is(err, leveldb.ErrNotFound) {
 			return nil, err
 		}
 		sws[addr] = substate.NewAccount(acc.Nonce, acc.Balance, code)

--- a/updateset/update_set.go
+++ b/updateset/update_set.go
@@ -1,9 +1,12 @@
 package updateset
 
 import (
+	"errors"
+
 	"github.com/Fantom-foundation/Substate/rlp"
 	"github.com/Fantom-foundation/Substate/substate"
 	"github.com/Fantom-foundation/Substate/types"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func NewUpdateSet(alloc substate.WorldState, block uint64) *UpdateSet {
@@ -54,7 +57,7 @@ func (up UpdateSetRLP) ToWorldState(getCodeFunc func(codeHash types.Hash) ([]byt
 		worldStateAcc := up.WorldState.Accounts[i]
 
 		code, err := getCodeFunc(worldStateAcc.CodeHash)
-		if err != nil {
+		if err != nil && !errors.Is(err, leveldb.ErrNotFound) {
 			return nil, err
 		}
 


### PR DESCRIPTION
This PR 
1) Replaces `%v` for `%w` when returning error so that the error still contains `leveldb.ErrNotFound` type.
2) Checks for this error when data is not found and returns nil data instead of an error.
