### PR TITLE
Allow stopping even if workers result channel is full.

### DIFF
--- a/db/substate_iterator.go
+++ b/db/substate_iterator.go
@@ -105,7 +105,12 @@ func (i *substateIterator) start(numWorkers int) {
 						errCh <- err
 						return
 					}
-					resultChs[id] <- transaction
+					select {
+					case resultChs[id] <- transaction:
+					case <-i.stopCh:
+						return
+
+					}
 				}
 
 			}


### PR DESCRIPTION
This PR fixes a rare deadlock with adding a `select` with a stop opportunity, caused by full channel.