### PR TITLE
Cancun RLP

### DIFF
--- a/rlp/berlin.go
+++ b/rlp/berlin.go
@@ -6,17 +6,24 @@ import (
 	"github.com/Fantom-foundation/Substate/types"
 )
 
-// legacySubstateRLP represents legacy RLP structure between before Berlin fork thus before berlinBlock
-type legacySubstateRLP struct {
+const berlinBlock = 37_455_223
+
+// IsBerlinFork returns true if block is part of the berlin fork block range
+func IsBerlinFork(block uint64) bool {
+	return block >= berlinBlock && block < londonBlock
+}
+
+// berlinRLP represents legacy RLP structure between Berlin and London fork starting at berlinBlock ending at londonBlock
+type berlinRLP struct {
 	InputAlloc  WorldState
 	OutputAlloc WorldState
 	Env         *legacyEnv
-	Message     *legacyMessage
+	Message     *berlinMessage
 	Result      *Result
 }
 
 // toRLP transforms r into RLP format which is compatible with the currently used Geth fork.
-func (r legacySubstateRLP) toRLP() *RLP {
+func (r berlinRLP) toRLP() *RLP {
 	return &RLP{
 		InputSubstate:  r.InputAlloc,
 		OutputSubstate: r.OutputAlloc,
@@ -24,9 +31,10 @@ func (r legacySubstateRLP) toRLP() *RLP {
 		Message:        r.Message.toMessage(),
 		Result:         r.Result,
 	}
+
 }
 
-type legacyMessage struct {
+type berlinMessage struct {
 	Nonce      uint64
 	CheckNonce bool
 	GasPrice   *big.Int
@@ -38,10 +46,12 @@ type legacyMessage struct {
 	Data  []byte
 
 	InitCodeHash *types.Hash `rlp:"nil"` // NOT nil for contract creation
+
+	AccessList types.AccessList // missing in substate DB from Geth v1.9.x
 }
 
 // toMessage transforms m into RLP format which is compatible with the currently used Geth fork.
-func (m legacyMessage) toMessage() *Message {
+func (m berlinMessage) toMessage() *Message {
 	return &Message{
 		londonMessage: londonMessage{
 			Nonce:        m.Nonce,
@@ -53,34 +63,11 @@ func (m legacyMessage) toMessage() *Message {
 			Value:        new(big.Int).Set(m.Value),
 			Data:         m.Data,
 			InitCodeHash: m.InitCodeHash,
-			AccessList:   nil, // access list was not present before berlin fork?
+			AccessList:   m.AccessList,
 
 			// Same behavior as AccessListTx.gasFeeCap() and AccessListTx.gasTipCap()
 			GasFeeCap: m.GasPrice,
 			GasTipCap: m.GasPrice,
-		},
-	}
-}
-
-type legacyEnv struct {
-	Coinbase    types.Address
-	Difficulty  *big.Int
-	GasLimit    uint64
-	Number      uint64
-	Timestamp   uint64
-	BlockHashes [][2]types.Hash
-}
-
-// toEnv transforms e into RLP format which is compatible with the currently used Geth fork.
-func (e legacyEnv) toEnv() *Env {
-	return &Env{
-		londonEnv: londonEnv{
-			Coinbase:    e.Coinbase,
-			Difficulty:  e.Difficulty,
-			GasLimit:    e.GasLimit,
-			Number:      e.Number,
-			Timestamp:   e.Timestamp,
-			BlockHashes: e.BlockHashes,
 		},
 	}
 }

--- a/rlp/berlin.go
+++ b/rlp/berlin.go
@@ -6,13 +6,6 @@ import (
 	"github.com/Fantom-foundation/Substate/types"
 )
 
-const berlinBlock = 37_455_223
-
-// IsBerlinFork returns true if block is part of the berlin fork block range
-func IsBerlinFork(block uint64) bool {
-	return block >= berlinBlock && block < londonBlock
-}
-
 // berlinRLP represents legacy RLP structure between Berlin and London fork starting at berlinBlock ending at londonBlock
 type berlinRLP struct {
 	InputAlloc  WorldState
@@ -53,21 +46,19 @@ type berlinMessage struct {
 // toMessage transforms m into RLP format which is compatible with the currently used Geth fork.
 func (m berlinMessage) toMessage() *Message {
 	return &Message{
-		londonMessage: londonMessage{
-			Nonce:        m.Nonce,
-			CheckNonce:   m.CheckNonce,
-			GasPrice:     m.GasPrice,
-			Gas:          m.Gas,
-			From:         m.From,
-			To:           m.To,
-			Value:        new(big.Int).Set(m.Value),
-			Data:         m.Data,
-			InitCodeHash: m.InitCodeHash,
-			AccessList:   m.AccessList,
+		Nonce:        m.Nonce,
+		CheckNonce:   m.CheckNonce,
+		GasPrice:     m.GasPrice,
+		Gas:          m.Gas,
+		From:         m.From,
+		To:           m.To,
+		Value:        new(big.Int).Set(m.Value),
+		Data:         m.Data,
+		InitCodeHash: m.InitCodeHash,
+		AccessList:   m.AccessList,
 
-			// Same behavior as AccessListTx.gasFeeCap() and AccessListTx.gasTipCap()
-			GasFeeCap: m.GasPrice,
-			GasTipCap: m.GasPrice,
-		},
+		// Same behavior as AccessListTx.gasFeeCap() and AccessListTx.gasTipCap()
+		GasFeeCap: m.GasPrice,
+		GasTipCap: m.GasPrice,
 	}
 }

--- a/rlp/legacy.go
+++ b/rlp/legacy.go
@@ -43,22 +43,20 @@ type legacyMessage struct {
 // toMessage transforms m into RLP format which is compatible with the currently used Geth fork.
 func (m legacyMessage) toMessage() *Message {
 	return &Message{
-		londonMessage: londonMessage{
-			Nonce:        m.Nonce,
-			CheckNonce:   m.CheckNonce,
-			GasPrice:     m.GasPrice,
-			Gas:          m.Gas,
-			From:         m.From,
-			To:           m.To,
-			Value:        new(big.Int).Set(m.Value),
-			Data:         m.Data,
-			InitCodeHash: m.InitCodeHash,
-			AccessList:   nil, // access list was not present before berlin fork?
+		Nonce:        m.Nonce,
+		CheckNonce:   m.CheckNonce,
+		GasPrice:     m.GasPrice,
+		Gas:          m.Gas,
+		From:         m.From,
+		To:           m.To,
+		Value:        new(big.Int).Set(m.Value),
+		Data:         m.Data,
+		InitCodeHash: m.InitCodeHash,
+		AccessList:   nil, // access list was not present before berlin fork?
 
-			// Same behavior as AccessListTx.gasFeeCap() and AccessListTx.gasTipCap()
-			GasFeeCap: m.GasPrice,
-			GasTipCap: m.GasPrice,
-		},
+		// Same behavior as AccessListTx.gasFeeCap() and AccessListTx.gasTipCap()
+		GasFeeCap: m.GasPrice,
+		GasTipCap: m.GasPrice,
 	}
 }
 
@@ -74,13 +72,11 @@ type legacyEnv struct {
 // toEnv transforms e into RLP format which is compatible with the currently used Geth fork.
 func (e legacyEnv) toEnv() *Env {
 	return &Env{
-		londonEnv: londonEnv{
-			Coinbase:    e.Coinbase,
-			Difficulty:  e.Difficulty,
-			GasLimit:    e.GasLimit,
-			Number:      e.Number,
-			Timestamp:   e.Timestamp,
-			BlockHashes: e.BlockHashes,
-		},
+		Coinbase:    e.Coinbase,
+		Difficulty:  e.Difficulty,
+		GasLimit:    e.GasLimit,
+		Number:      e.Number,
+		Timestamp:   e.Timestamp,
+		BlockHashes: e.BlockHashes,
 	}
 }

--- a/rlp/london.go
+++ b/rlp/london.go
@@ -1,0 +1,145 @@
+package rlp
+
+import (
+	"math/big"
+
+	"github.com/Fantom-foundation/Substate/substate"
+	"github.com/Fantom-foundation/Substate/types"
+)
+
+const londonBlock = 37_534_833
+
+// IsLondonFork returns true if block is part of the london fork block range
+func IsLondonFork(block uint64) bool {
+	return block >= londonBlock
+}
+
+func NewLondonRLP(substate *substate.Substate) *londonRLP {
+	return &londonRLP{
+		InputSubstate:  NewWorldState(substate.InputSubstate),
+		OutputSubstate: NewWorldState(substate.OutputSubstate),
+		Env:            newLondonEnv(substate.Env),
+		Message:        newLondonMessage(substate.Message),
+		Result:         NewResult(substate.Result),
+	}
+}
+
+// londonRLP represents RLP structure after londonBlock and before cancun fork.
+type londonRLP struct {
+	InputSubstate  WorldState
+	OutputSubstate WorldState
+	Env            londonEnv
+	Message        londonMessage
+	Result         *Result
+}
+
+// toRLP transforms r into RLP format which is compatible with the currently used Geth fork.
+func (r londonRLP) toRLP() *RLP {
+	return &RLP{
+		InputSubstate:  r.InputSubstate,
+		OutputSubstate: r.OutputSubstate,
+		Env:            r.Env.toEnv(),
+		Message:        r.Message.toMessage(),
+		Result:         r.Result,
+	}
+}
+
+func newLondonEnv(env *substate.Env) londonEnv {
+	e := londonEnv{
+		Coinbase:   env.Coinbase,
+		Difficulty: env.Difficulty,
+		GasLimit:   env.GasLimit,
+		Number:     env.Number,
+		Timestamp:  env.Timestamp,
+	}
+
+	var sortedNum64 []uint64
+	for num64 := range env.BlockHashes {
+		sortedNum64 = append(sortedNum64, num64)
+	}
+
+	for _, num64 := range sortedNum64 {
+		num := types.BigToHash(new(big.Int).SetUint64(num64))
+		blockHash := env.BlockHashes[num64]
+		pair := [2]types.Hash{num, blockHash}
+		e.BlockHashes = append(e.BlockHashes, pair)
+	}
+
+	e.BaseFee = nil
+	if env.BaseFee != nil {
+		baseFeeHash := types.BigToHash(env.BaseFee)
+		e.BaseFee = &baseFeeHash
+	}
+
+	return e
+}
+
+type londonEnv struct {
+	Coinbase    types.Address
+	Difficulty  *big.Int
+	GasLimit    uint64
+	Number      uint64
+	Timestamp   uint64
+	BlockHashes [][2]types.Hash
+
+	BaseFee *types.Hash `rlp:"nil"` // missing in substate DB from Geth <= v1.10.3
+}
+
+// toEnv transforms m into RLP format which is compatible with the currently used Geth fork.
+func (e londonEnv) toEnv() *Env {
+	return &Env{
+		londonEnv: e,
+	}
+}
+
+func newLondonMessage(message *substate.Message) londonMessage {
+	m := londonMessage{
+		Nonce:        message.Nonce,
+		CheckNonce:   message.CheckNonce,
+		GasPrice:     message.GasPrice,
+		Gas:          message.Gas,
+		From:         message.From,
+		To:           message.To,
+		Value:        new(big.Int).Set(message.Value),
+		Data:         message.Data,
+		InitCodeHash: nil,
+		AccessList:   message.AccessList,
+		GasFeeCap:    message.GasFeeCap,
+		GasTipCap:    message.GasTipCap,
+	}
+
+	if m.To == nil {
+		// put contract creation init code into codeDB
+		dataHash := message.DataHash()
+		m.InitCodeHash = &dataHash
+		m.Data = nil
+	}
+
+	return m
+}
+
+type londonMessage struct {
+	Nonce      uint64
+	CheckNonce bool
+	GasPrice   *big.Int
+	Gas        uint64
+
+	From  types.Address
+	To    *types.Address `rlp:"nil"` // nil means contract creation
+	Value *big.Int
+	Data  []byte
+
+	InitCodeHash *types.Hash `rlp:"nil"` // NOT nil for contract creation
+
+	AccessList types.AccessList // missing in substate DB from Geth v1.9.x
+
+	GasFeeCap *big.Int // missing in substate DB from Geth <= v1.10.3
+	GasTipCap *big.Int // missing in substate DB from Geth <= v1.10.3
+}
+
+// toMessage transforms m into RLP format which is compatible with the currently used Geth fork.
+func (m londonMessage) toMessage() *Message {
+	return &Message{
+		londonMessage: m,
+	}
+}

--- a/rlp/rlp.go
+++ b/rlp/rlp.go
@@ -43,8 +43,8 @@ func Decode(val []byte) (*RLP, error) {
 
 	var legacy legacySubstateRLP
 	err = rlp.DecodeBytes(val, &legacy)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		return legacy.toRLP(), nil
 	}
 
 	// cancun
@@ -54,7 +54,7 @@ func Decode(val []byte) (*RLP, error) {
 		return &substateRLP, nil
 	}
 
-	return legacy.toRLP(), nil
+	return nil, err
 }
 
 // ToSubstate transforms every attribute of r from RLP to substate.Substate.

--- a/rlp/rlp_env.go
+++ b/rlp/rlp_env.go
@@ -9,7 +9,18 @@ import (
 
 func NewEnv(env *substate.Env) *Env {
 	e := &Env{
-		londonEnv: newLondonEnv(env),
+		Coinbase:    env.Coinbase,
+		Difficulty:  env.Difficulty,
+		GasLimit:    env.GasLimit,
+		Number:      env.Number,
+		Timestamp:   env.Timestamp,
+		BlockHashes: createBlockHashes(env.BlockHashes),
+	}
+
+	e.BaseFee = nil
+	if env.BaseFee != nil {
+		baseFee := types.BigToHash(env.BaseFee)
+		e.BaseFee = &baseFee
 	}
 
 	e.BlobBaseFee = nil
@@ -22,7 +33,14 @@ func NewEnv(env *substate.Env) *Env {
 }
 
 type Env struct {
-	londonEnv
+	Coinbase    types.Address
+	Difficulty  *big.Int
+	GasLimit    uint64
+	Number      uint64
+	Timestamp   uint64
+	BlockHashes [][2]types.Hash
+
+	BaseFee     *types.Hash `rlp:"nil"` // missing in substate DB from Geth <= v1.10.3
 	BlobBaseFee *types.Hash `rlp:"nil"` // missing in substate DB before Cancun
 }
 

--- a/rlp/rlp_env.go
+++ b/rlp/rlp_env.go
@@ -9,30 +9,7 @@ import (
 
 func NewEnv(env *substate.Env) *Env {
 	e := &Env{
-		Coinbase:    env.Coinbase,
-		Difficulty:  env.Difficulty,
-		GasLimit:    env.GasLimit,
-		Number:      env.Number,
-		Timestamp:   env.Timestamp,
-		BlockHashes: nil,
-	}
-
-	var sortedNum64 []uint64
-	for num64 := range env.BlockHashes {
-		sortedNum64 = append(sortedNum64, num64)
-	}
-
-	for _, num64 := range sortedNum64 {
-		num := types.BigToHash(new(big.Int).SetUint64(num64))
-		blockHash := env.BlockHashes[num64]
-		pair := [2]types.Hash{num, blockHash}
-		e.BlockHashes = append(e.BlockHashes, pair)
-	}
-
-	e.BaseFee = nil
-	if env.BaseFee != nil {
-		baseFeeHash := types.BigToHash(env.BaseFee)
-		e.BaseFee = &baseFeeHash
+		londonEnv: newLondonEnv(env),
 	}
 
 	e.BlobBaseFee = nil
@@ -45,14 +22,7 @@ func NewEnv(env *substate.Env) *Env {
 }
 
 type Env struct {
-	Coinbase    types.Address
-	Difficulty  *big.Int
-	GasLimit    uint64
-	Number      uint64
-	Timestamp   uint64
-	BlockHashes [][2]types.Hash
-
-	BaseFee     *types.Hash `rlp:"nil"` // missing in substate DB from Geth <= v1.10.3
+	londonEnv
 	BlobBaseFee *types.Hash `rlp:"nil"` // missing in substate DB before Cancun
 }
 

--- a/rlp/rlp_message.go
+++ b/rlp/rlp_message.go
@@ -11,49 +11,16 @@ import (
 
 func NewMessage(message *substate.Message) *Message {
 	m := &Message{
-		Nonce:         message.Nonce,
-		CheckNonce:    message.CheckNonce,
-		GasPrice:      message.GasPrice,
-		Gas:           message.Gas,
-		From:          message.From,
-		To:            message.To,
-		Value:         new(big.Int).Set(message.Value),
-		Data:          message.Data,
-		InitCodeHash:  nil,
-		AccessList:    message.AccessList,
-		GasFeeCap:     message.GasFeeCap,
-		GasTipCap:     message.GasTipCap,
+		londonMessage: newLondonMessage(message),
 		BlobGasFeeCap: message.BlobGasFeeCap,
 		BlobHashes:    message.BlobHashes,
-	}
-
-	if m.To == nil {
-		// put contract creation init code into codeDB
-		dataHash := message.DataHash()
-		m.InitCodeHash = &dataHash
-		m.Data = nil
 	}
 
 	return m
 }
 
 type Message struct {
-	Nonce      uint64
-	CheckNonce bool
-	GasPrice   *big.Int
-	Gas        uint64
-
-	From  types.Address
-	To    *types.Address `rlp:"nil"` // nil means contract creation
-	Value *big.Int
-	Data  []byte
-
-	InitCodeHash *types.Hash `rlp:"nil"` // NOT nil for contract creation
-
-	AccessList types.AccessList // missing in substate DB from Geth v1.9.x
-
-	GasFeeCap *big.Int // missing in substate DB from Geth <= v1.10.3
-	GasTipCap *big.Int // missing in substate DB from Geth <= v1.10.3
+	londonMessage
 
 	BlobGasFeeCap *big.Int     // missing in substate DB from Geth before Cancun
 	BlobHashes    []types.Hash // missing in substate DB from Geth before Cancun

--- a/rlp/rlp_message.go
+++ b/rlp/rlp_message.go
@@ -9,18 +9,43 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-func NewMessage(message *substate.Message) *Message {
-	m := &Message{
-		londonMessage: newLondonMessage(message),
-		BlobGasFeeCap: message.BlobGasFeeCap,
-		BlobHashes:    message.BlobHashes,
+func NewMessage(sm *substate.Message) *Message {
+	mess := &Message{
+		Nonce:         sm.Nonce,
+		CheckNonce:    sm.CheckNonce,
+		GasPrice:      sm.GasPrice,
+		Gas:           sm.Gas,
+		From:          sm.From,
+		To:            sm.To,
+		Value:         new(big.Int).Set(sm.Value),
+		Data:          sm.Data,
+		AccessList:    sm.AccessList,
+		GasFeeCap:     sm.GasFeeCap,
+		GasTipCap:     sm.GasTipCap,
+		BlobGasFeeCap: sm.BlobGasFeeCap,
+		BlobHashes:    sm.BlobHashes,
 	}
 
-	return m
+	return mess
 }
 
 type Message struct {
-	londonMessage
+	Nonce      uint64
+	CheckNonce bool
+	GasPrice   *big.Int
+	Gas        uint64
+
+	From  types.Address
+	To    *types.Address `rlp:"nil"` // nil means contract creation
+	Value *big.Int
+	Data  []byte
+
+	InitCodeHash *types.Hash `rlp:"nil"` // NOT nil for contract creation
+
+	AccessList types.AccessList // missing in substate DB from Geth v1.9.x
+
+	GasFeeCap *big.Int // missing in substate DB from Geth <= v1.10.3
+	GasTipCap *big.Int // missing in substate DB from Geth <= v1.10.3
 
 	BlobGasFeeCap *big.Int     // missing in substate DB from Geth before Cancun
 	BlobHashes    []types.Hash // missing in substate DB from Geth before Cancun

--- a/rlp/rlp_test.go
+++ b/rlp/rlp_test.go
@@ -14,10 +14,30 @@ var (
 	hash1 = types.Hash{0x01}
 )
 
-func Test_DecodeLondon(t *testing.T) {
+func Test_Decode(t *testing.T) {
 	london := RLP{
 		Message: &Message{Data: []byte{1}, Value: big.NewInt(1), GasPrice: big.NewInt(1)},
 		Env:     &Env{},
+		Result:  &Result{}}
+	b, err := rlp.EncodeToBytes(london)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := Decode(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(res.Message.Data, []byte{1}) {
+		t.Fatal("incorrect data")
+	}
+}
+
+func Test_DecodeLondon(t *testing.T) {
+	london := londonRLP{
+		Message: londonMessage{Data: []byte{1}, Value: big.NewInt(1), GasPrice: big.NewInt(1)},
+		Env:     londonEnv{},
 		Result:  &Result{}}
 	b, err := rlp.EncodeToBytes(london)
 	if err != nil {


### PR DESCRIPTION
## Description

This PR correctly implements addition of data added in `Cancun` fork into `RLP` package.
The RLPs need to be separate because the way `Decode` works is that it tries to decode RLP into structure, if it fails it tries another structure. As

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
