### PR TITLE
Fix incorrect message transition

### DIFF
--- a/rlp/london.go
+++ b/rlp/london.go
@@ -146,6 +146,7 @@ func (m londonMessage) toMessage() *Message {
 		Nonce:        m.Nonce,
 		CheckNonce:   m.CheckNonce,
 		GasPrice:     m.GasPrice,
+		Gas:          m.Gas,
 		From:         m.From,
 		To:           m.To,
 		Value:        m.Value,

--- a/rlp/rlp_message.go
+++ b/rlp/rlp_message.go
@@ -26,6 +26,13 @@ func NewMessage(sm *substate.Message) *Message {
 		BlobHashes:    sm.BlobHashes,
 	}
 
+	if mess.To == nil {
+		// put contract creation init code into codeDB
+		dataHash := sm.DataHash()
+		mess.InitCodeHash = &dataHash
+		mess.Data = nil
+	}
+
 	return mess
 }
 

--- a/rlp/rlp_message_test.go
+++ b/rlp/rlp_message_test.go
@@ -1,0 +1,17 @@
+package rlp
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/Fantom-foundation/Substate/substate"
+	"github.com/Fantom-foundation/Substate/types/hash"
+)
+
+func TestNewMessage_InitCodeHashIsCreated_WhenToIsNil(t *testing.T) {
+	data := []byte{0x1}
+	m := NewMessage(&substate.Message{Data: data, Value: big.NewInt(1), To: nil})
+	if got, want := *m.InitCodeHash, hash.Keccak256Hash(data); got != want {
+		t.Fatalf("unexpected code hash\ngot: %s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
## Description

This PR fixes `gas` not being passed from `rlpLondonMessage` to `Message`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
