### PR TITLE
[Flag] Add Flag to switch between RLP and other future encoding

### DIFF
--- a/db/substate_db_test.go
+++ b/db/substate_db_test.go
@@ -72,6 +72,10 @@ func TestSubstateDB_GetSubstate(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	testSubstateDB_GetSubstate(db, t)
+}
+
+func testSubstateDB_GetSubstate(db *substateDB, t *testing.T) {
 	ss, err := db.GetSubstate(37_534_834, 1)
 	if err != nil {
 		t.Fatalf("get substate returned error; %v", err)
@@ -84,6 +88,7 @@ func TestSubstateDB_GetSubstate(t *testing.T) {
 	if err = ss.Equal(testSubstate); err != nil {
 		t.Fatalf("substates are different; %v", err)
 	}
+
 }
 
 func TestSubstateDB_DeleteSubstate(t *testing.T) {
@@ -200,13 +205,17 @@ func createDbAndPutSubstate(dbPath string) (*substateDB, error) {
 }
 
 func addSubstate(db *substateDB, blk uint64) error {
+	return addCustomSubstate(db, blk, testSubstate)
+}
+
+func addCustomSubstate(db *substateDB, blk uint64, ss *substate.Substate) error {
 	h1 := types.Hash{}
 	h1.SetBytes(nil)
 
 	h2 := types.Hash{}
 	h2.SetBytes(nil)
 
-	s := *testSubstate
+	s := *ss
 
 	s.InputSubstate[types.Address{1}] = substate.NewAccount(1, new(big.Int).SetUint64(1), h1[:])
 	s.OutputSubstate[types.Address{2}] = substate.NewAccount(2, new(big.Int).SetUint64(2), h2[:])

--- a/db/substate_encoding.go
+++ b/db/substate_encoding.go
@@ -34,17 +34,17 @@ func (db *substateDB) GetSubstateEncoding() string {
 
 type substateEncoding struct {
 	schema string
-	decode decoderFunc
+	decode decodeFunc
 }
 
-// decoderFunc aliases the common function used to decode substate
+// decodeFunc aliases the common function used to decode substate
 type decodeFunc func([]byte, uint64, int) (*substate.Substate, error)
 
-// codeLookup aliases codehash->code lookup necessary to decode substate
+// codeLookupFunc aliases codehash->code lookup necessary to decode substate
 type codeLookupFunc = func(types.Hash) ([]byte, error)
 
 // newSubstateDecoder returns requested SubstateDecoder
-func newSubstateEncoding(encoding string, lookup codeLookup) (*substateEncoding, error) {
+func newSubstateEncoding(encoding string, lookup codeLookupFunc) (*substateEncoding, error) {
 	switch encoding {
 
 	case "default", "rlp":
@@ -70,7 +70,7 @@ func (db *substateDB) decodeToSubstate(bytes []byte, block uint64, tx int) (*sub
 }
 
 // decodeRlp decodes into substate the provided rlp-encoded bytecode
-func decodeRlp(bytes []byte, lookup codeLookup, block uint64, tx int) (*substate.Substate, error) {
+func decodeRlp(bytes []byte, lookup codeLookupFunc, block uint64, tx int) (*substate.Substate, error) {
 	rlpSubstate, err := rlp.Decode(bytes)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decode substate data from rlp block: %v, tx %v; %w", block, tx, err)

--- a/db/substate_encoding.go
+++ b/db/substate_encoding.go
@@ -1,0 +1,80 @@
+package db
+
+import (
+	"fmt"
+
+	"github.com/Fantom-foundation/Substate/rlp"
+	"github.com/Fantom-foundation/Substate/substate"
+	"github.com/Fantom-foundation/Substate/types"
+)
+
+// SetSubstateEncoding sets the runtime encoding/decoding behavior of substateDB
+// intended usage:
+//
+//		db := &substateDB{..}
+//	     db, err := db.SetSubstateEncoding(<schema>) // set encoding
+//	     db.GetSubstateDecoder() // returns configured encoding
+func (db *substateDB) SetSubstateEncoding(schema string) (*substateDB, error) {
+	encoding, err := newSubstateEncoding(schema, db.GetCode)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to set decoder; %w", err)
+	}
+
+	db.encoding = encoding
+	return db, nil
+}
+
+// GetDecoder returns the encoding in use
+func (db *substateDB) GetSubstateEncoding() string {
+	if db.encoding == nil {
+		return ""
+	}
+	return db.encoding.schema
+}
+
+type substateEncoding struct {
+	schema string
+	decode decoderFunc
+}
+
+// decoderFunc aliases the common function used to decode substate
+type decoderFunc func([]byte, uint64, int) (*substate.Substate, error)
+
+// codeLookup aliases codehash->code lookup necessary to decode substate
+type codeLookup = func(types.Hash) ([]byte, error)
+
+// newSubstateDecoder returns requested SubstateDecoder
+func newSubstateEncoding(encoding string, lookup codeLookup) (*substateEncoding, error) {
+	switch encoding {
+
+	case "default", "rlp":
+		return &substateEncoding{
+			schema: "rlp",
+			decode: func(bytes []byte, block uint64, tx int) (*substate.Substate, error) {
+				return decodeRlp(bytes, lookup, block, tx)
+			},
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("Encoding not supported: %s", encoding)
+
+	}
+}
+
+// decodeSubstate defensively defaults to "default" if nil
+func (db *substateDB) decodeToSubstate(bytes []byte, block uint64, tx int) (*substate.Substate, error) {
+	if db.encoding == nil {
+		db.SetSubstateEncoding("default")
+	}
+	return db.encoding.decode(bytes, block, tx)
+}
+
+// decodeRlp decodes into substate the provided rlp-encoded bytecode
+func decodeRlp(bytes []byte, lookup codeLookup, block uint64, tx int) (*substate.Substate, error) {
+	rlpSubstate, err := rlp.Decode(bytes)
+	if err != nil {
+		return nil, fmt.Errorf("cannot decode substate data from rlp block: %v, tx %v; %w", block, tx, err)
+	}
+
+	return rlpSubstate.ToSubstate(lookup, block, tx)
+}

--- a/db/substate_encoding.go
+++ b/db/substate_encoding.go
@@ -38,10 +38,10 @@ type substateEncoding struct {
 }
 
 // decoderFunc aliases the common function used to decode substate
-type decoderFunc func([]byte, uint64, int) (*substate.Substate, error)
+type decodeFunc func([]byte, uint64, int) (*substate.Substate, error)
 
 // codeLookup aliases codehash->code lookup necessary to decode substate
-type codeLookup = func(types.Hash) ([]byte, error)
+type codeLookupFunc = func(types.Hash) ([]byte, error)
 
 // newSubstateDecoder returns requested SubstateDecoder
 func newSubstateEncoding(encoding string, lookup codeLookup) (*substateEncoding, error) {

--- a/db/substate_encoding_test.go
+++ b/db/substate_encoding_test.go
@@ -1,0 +1,130 @@
+package db
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Fantom-foundation/Substate/rlp"
+	trlp "github.com/Fantom-foundation/Substate/types/rlp"
+)
+
+var (
+	testRlp, _ = trlp.EncodeToBytes(rlp.NewRLP(testSubstate))
+	testBlk    = testSubstate.Block
+	testTx     = testSubstate.Transaction
+
+	supportedEncoding = map[string][]byte{
+		"rlp": testRlp,
+	}
+)
+
+func TestSubstateEncoding_NilEncodingDefaultsToRlp(t *testing.T) {
+	path := t.TempDir() + "test-db"
+	db, err := newSubstateDB(path, nil, nil, nil)
+	if err != nil {
+		t.Errorf("cannot open db; %v", err)
+	}
+
+	if got := db.GetSubstateEncoding(); got != "" {
+		t.Fatalf("substate encoding should be nil, got: %s", got)
+	}
+
+	// purposely never set encoding
+	_, err = db.decodeToSubstate(testRlp, testBlk, testTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := db.GetSubstateEncoding(); got != "rlp" {
+		t.Fatalf("db should default to rlp, got: %s", got)
+	}
+}
+
+func TestSubstateEncoding_DefaultEncodingDefaultsToRlp(t *testing.T) {
+	path := t.TempDir() + "test-db"
+	db, err := newSubstateDB(path, nil, nil, nil)
+	if err != nil {
+		t.Errorf("cannot open db; %v", err)
+	}
+
+	_, err = db.SetSubstateEncoding("default")
+	if err != nil {
+		t.Fatal("default is supportet, but error")
+	}
+
+	_, err = db.decodeToSubstate(testRlp, testBlk, testTx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := db.GetSubstateEncoding(); got != "rlp" {
+		t.Fatalf("db should default to rlp, got: %s", got)
+	}
+}
+
+func TestSubstateEncoding_UnsupportedEncodingThrowsError(t *testing.T) {
+	path := t.TempDir() + "test-db"
+	db, err := newSubstateDB(path, nil, nil, nil)
+	if err != nil {
+		t.Errorf("cannot open db; %v", err)
+	}
+
+	_, err = db.SetSubstateEncoding("EncodingNotSupported")
+	if err == nil || !strings.Contains(err.Error(), "Encoding not supported") {
+		t.Error("Encoding not supported, but no error")
+	}
+}
+
+func TestSubstateEncoding_TestDb(t *testing.T) {
+	path := t.TempDir() + "test-db"
+	db, err := newSubstateDB(path, nil, nil, nil)
+	if err != nil {
+		t.Errorf("cannot open db; %v", err)
+	}
+
+	for encoding, bytes := range supportedEncoding {
+		_, err = db.SetSubstateEncoding(encoding)
+		if err != nil {
+			t.Error(err)
+		}
+
+		ss, err := db.decodeToSubstate(bytes, testBlk, testTx)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = addCustomSubstate(db, testBlk, ss)
+		if err != nil {
+			t.Error(err)
+		}
+
+		testSubstateDB_GetSubstate(db, t)
+	}
+}
+
+func TestSubstateEncoding_TestIterator(t *testing.T) {
+	path := t.TempDir() + "test-db"
+	db, err := newSubstateDB(path, nil, nil, nil)
+	if err != nil {
+		t.Errorf("cannot open db; %v", err)
+	}
+
+	for encoding, bytes := range supportedEncoding {
+		_, err = db.SetSubstateEncoding(encoding)
+		if err != nil {
+			t.Error(err)
+		}
+
+		ss, err := db.decodeToSubstate(bytes, testBlk, testTx)
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = addCustomSubstate(db, testBlk, ss)
+		if err != nil {
+			t.Error(err)
+		}
+
+		testSubstatorIterator_Value(db, t)
+	}
+}

--- a/db/substate_iterator.go
+++ b/db/substate_iterator.go
@@ -3,10 +3,8 @@ package db
 import (
 	"fmt"
 
-	"github.com/syndtr/goleveldb/leveldb/util"
-
-	"github.com/Fantom-foundation/Substate/rlp"
 	"github.com/Fantom-foundation/Substate/substate"
+	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 func newSubstateIterator(db *substateDB, start []byte) *substateIterator {
@@ -33,12 +31,7 @@ func (i *substateIterator) decode(data rawEntry) (*substate.Substate, error) {
 		return nil, fmt.Errorf("invalid substate key: %v; %w", key, err)
 	}
 
-	rlpSubstate, err := rlp.Decode(value)
-	if err != nil {
-		return nil, err
-	}
-
-	return rlpSubstate.ToSubstate(i.db.GetCode, block, tx)
+	return i.db.decodeToSubstate(value, block, tx)
 }
 
 func (i *substateIterator) start(numWorkers int) {

--- a/db/substate_iterator_test.go
+++ b/db/substate_iterator_test.go
@@ -29,6 +29,10 @@ func TestSubstateIterator_Value(t *testing.T) {
 		return
 	}
 
+	testSubstatorIterator_Value(db, t)
+}
+
+func testSubstatorIterator_Value(db *substateDB, t *testing.T) {
 	iter := db.NewSubstateIterator(0, 10)
 
 	if !iter.Next() {
@@ -48,6 +52,7 @@ func TestSubstateIterator_Value(t *testing.T) {
 	if tx.Transaction != 1 {
 		t.Fatalf("iterator returned transaction with different transaction number\ngot: %v\n want: %v", tx.Transaction, 1)
 	}
+
 }
 
 func TestSubstateIterator_Release(t *testing.T) {


### PR DESCRIPTION
In anticipation of adding protobuf encoding, a `SetSubstateEncoding` function is added to `SubstateDB`.
Currently, only option available is "rlp".
If unset or set to "default", rlp is selected.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Adds or updates testing
