### PR TITLE
Remove Keccak256

### DIFF
--- a/protobuf/decode.go
+++ b/protobuf/decode.go
@@ -224,7 +224,7 @@ func (msg *Substate_TxMessage) getContractAddress() types.Address {
 // mimics crypto.CreateAddress, to avoid cyclical dependency.
 func createAddress(addr types.Address, nonce uint64) types.Address {
 	data, _ := trlp.EncodeToBytes([]interface{}{addr, nonce})
-	return types.BytesToAddress(hash.Keccak256(data)[12:])
+	return types.BytesToAddress(hash.Keccak256Hash(data).Bytes()[12:])
 }
 
 // decode converts protobuf-encoded Substate_Result into aida-comprehensible Result

--- a/types/hash/hash.go
+++ b/types/hash/hash.go
@@ -37,17 +37,6 @@ func NewKeccakState() KeccakState {
 	return sha3.NewLegacyKeccak256().(KeccakState)
 }
 
-// Keccak256 calculates and returns the Keccak256 hash of the input data.
-func Keccak256(data ...[]byte) []byte {
-	b := make([]byte, 32)
-	d := NewKeccakState()
-	for _, b := range data {
-		d.Write(b)
-	}
-	d.Read(b)
-	return b
-}
-
 // Keccak256Hash calculates and returns the Keccak256 hash of the input data,
 // converting it to an internal Hash data structure.
 func Keccak256Hash(data ...[]byte) (h types.Hash) {


### PR DESCRIPTION
To minimize dependency on geth, newly introduced `Keccak256` is to be deprecated in favor of using already-existed `Keccak256Hash`.

## Type of change
- [ ] Refactoring (changes that do NOT affect functionality)
